### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/class-associations.R
+++ b/R/class-associations.R
@@ -92,7 +92,7 @@ setOldClass(c("tbl_df", "tbl", "data.frame"))
 #' \item{gene_name}{Gene symbol according to
 #' \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
 #' \item{entrez_id}{The Entrez identifier of a gene, see ref.
-#' \href{https://dx.doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
+#' \href{https://doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
 #' more information.}
 #' \item{ensembl_id}{The Ensembl identifier of an Ensembl gene, see Section
 #' \href{https://tinyurl.com/yxufd22b}{Gene
@@ -107,7 +107,7 @@ setOldClass(c("tbl_df", "tbl", "data.frame"))
 #' \item{gene_name}{Gene symbol according to
 #' \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
 #' \item{entrez_id}{The Entrez identifier of a gene, see ref.
-#' \href{https://dx.doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
+#' \href{https://doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
 #' more information.}
 #' }
 #' @export

--- a/R/class-variants.R
+++ b/R/class-variants.R
@@ -58,7 +58,7 @@ setOldClass(c("tbl_df", "tbl", "data.frame"))
 #' \item{gene_name}{Gene symbol according to
 #' \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
 #' \item{entrez_id}{The Entrez identifier of a gene, see ref.
-#' \href{https://dx.doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
+#' \href{https://doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
 #' more information.}
 #' }
 #' @export

--- a/docs/reference/associations-class.html
+++ b/docs/reference/associations-class.html
@@ -236,7 +236,7 @@ a multi-loci entity such as a multi-SNP haplotype.</p></dd>
 <dt>gene_name</dt><dd><p>Gene symbol according to
 <a href='https://www.genenames.org/'>HUGO Gene Nomenclature (HGNC)</a>.</p></dd>
 <dt>entrez_id</dt><dd><p>The Entrez identifier of a gene, see ref.
-<a href='https://dx.doi.org/10.1093%2Fnar%2Fgkq1237'>10.1093/nar/gkq1237</a> for
+<a href='https://doi.org/10.1093%2Fnar%2Fgkq1237'>10.1093/nar/gkq1237</a> for
 more information.</p></dd>
 <dt>ensembl_id</dt><dd><p>The Ensembl identifier of an Ensembl gene, see Section
 <a href='https://tinyurl.com/yxufd22b'>Gene
@@ -251,7 +251,7 @@ a multi-loci entity such as a multi-SNP haplotype.</p></dd>
 <dt>gene_name</dt><dd><p>Gene symbol according to
 <a href='https://www.genenames.org/'>HUGO Gene Nomenclature (HGNC)</a>.</p></dd>
 <dt>entrez_id</dt><dd><p>The Entrez identifier of a gene, see ref.
-<a href='https://dx.doi.org/10.1093%2Fnar%2Fgkq1237'>10.1093/nar/gkq1237</a> for
+<a href='https://doi.org/10.1093%2Fnar%2Fgkq1237'>10.1093/nar/gkq1237</a> for
 more information.</p></dd>
 </dl></p></dd>
 </dl>

--- a/docs/reference/variants-class.html
+++ b/docs/reference/variants-class.html
@@ -202,7 +202,7 @@ annotation in Ensembl</a> for more information.</p></dd>
 <dt>gene_name</dt><dd><p>Gene symbol according to
 <a href='https://www.genenames.org/'>HUGO Gene Nomenclature (HGNC)</a>.</p></dd>
 <dt>entrez_id</dt><dd><p>The Entrez identifier of a gene, see ref.
-<a href='https://dx.doi.org/10.1093%2Fnar%2Fgkq1237'>10.1093/nar/gkq1237</a> for
+<a href='https://doi.org/10.1093%2Fnar%2Fgkq1237'>10.1093/nar/gkq1237</a> for
 more information.</p></dd>
 </dl></p></dd>
 </dl>

--- a/man/associations-class.Rd
+++ b/man/associations-class.Rd
@@ -102,7 +102,7 @@ a multi-loci entity such as a multi-SNP haplotype.}
 \item{gene_name}{Gene symbol according to
 \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
 \item{entrez_id}{The Entrez identifier of a gene, see ref.
-\href{https://dx.doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
+\href{https://doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
 more information.}
 \item{ensembl_id}{The Ensembl identifier of an Ensembl gene, see Section
 \href{https://tinyurl.com/yxufd22b}{Gene
@@ -118,7 +118,7 @@ a multi-loci entity such as a multi-SNP haplotype.}
 \item{gene_name}{Gene symbol according to
 \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
 \item{entrez_id}{The Entrez identifier of a gene, see ref.
-\href{https://dx.doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
+\href{https://doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
 more information.}
 }}
 }}

--- a/man/variants-class.Rd
+++ b/man/variants-class.Rd
@@ -67,7 +67,7 @@ annotation in Ensembl} for more information.}
 \item{gene_name}{Gene symbol according to
 \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
 \item{entrez_id}{The Entrez identifier of a gene, see ref.
-\href{https://dx.doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
+\href{https://doi.org/10.1093\%2Fnar\%2Fgkq1237}{10.1093/nar/gkq1237} for
 more information.}
 }}
 }}


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!