### PR TITLE
Fix assocaitions-class.Rd

### DIFF
--- a/man/associations-class.Rd
+++ b/man/associations-class.Rd
@@ -101,8 +101,6 @@ a multi-loci entity such as a multi-SNP haplotype.}
 a multi-loci entity such as a multi-SNP haplotype.}
 \item{gene_name}{Gene symbol according to
 \href{https://www.genenames.org/}{HUGO Gene Nomenclature (HGNC)}.}
-\item{entrez_id}{The Entrez identifier of a gene, see
-\doi{10.1093/nar/gkq1237} for more information.}
 \item{ensembl_id}{The Ensembl identifier of an Ensembl gene, see Section
 \href{https://www.ensembl.org/info/genome/genebuild/index.html}{Gene
 annotation in Ensembl} for more information.} }}


### PR DESCRIPTION
`entrez_id`  is not available in the `Slot "ensembl_ids"`. The documentation [here](https://rmagno.eu/gwasrapidd/reference/associations-class.html) is not reflecting the association class functionality.